### PR TITLE
Fixed compatibility with Debian/RPiOS Bookworm

### DIFF
--- a/RPiCamGUI.py
+++ b/RPiCamGUI.py
@@ -320,7 +320,10 @@ def Camera_Version():
     # DETERMINE NUMBER OF CAMERAS (FOR ARDUCAM MULITPLEXER or Pi5)
     if os.path.exists('libcams.txt'):
         os.rename('libcams.txt', 'oldlibcams.txt')
-    os.system("libcamera-vid --list-cameras >> libcams.txt")
+    if lver != "bookworm":
+        os.system("libcamera-vid --list-cameras >> libcams.txt")
+    else:
+        os.system("rpicam-vid --list-cameras >> libcams.txt")
     time.sleep(0.5)
     # read libcams.txt file
     camstxt = []


### PR DESCRIPTION
Thanks for creating this, I found it very useful to test my camera setup...once I made **one small fix**:

I found the **ONE** place that ignored the version of Debian/RPiOS, which made this unusable on my Pi 4 running **_"Bookworm"_**. Added OS version check to _Camera_Version()_ so it wouldn't try to invoke _libcamera-vid_ on **_Debian "Bookworm"_**, but use _rpicam-vid_ instead.

Hope you find this helpful. Cheers!